### PR TITLE
fix: css is now imported as a string and appended to the document

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@twostoryrobot/storybook-addon-docgen",
-  "version": "0.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twostoryrobot/storybook-addon-docgen",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Generates documentation using react-docgen",
   "main": "dist/index.js",
   "scripts": {

--- a/src/css.js
+++ b/src/css.js
@@ -1,3 +1,4 @@
+export default `
 .storybook-addon-docgen {
   padding: 0 1em;
 }
@@ -11,3 +12,4 @@
 .storybook-addon-docgen tr:nth-child(even) {
   background-color: #F6F8FA;
 }
+`

--- a/src/register.js
+++ b/src/register.js
@@ -3,7 +3,11 @@ import addons from '@storybook/addons'
 import Markdown from 'react-markdown'
 import generateMarkdown from './generateMarkdown'
 
-import './index.css'
+import styles from './css'
+
+const style = document.createElement('style')
+style.innerHTML = styles
+document.body.appendChild(style)
 
 class DocgenPanel extends React.Component {
   constructor(props) {


### PR DESCRIPTION
This is a super simple way of adding the styles to the dom without needing an extra css-in-js library or using webpack css loaders.