### PR TITLE
v1.0.3 - actually run the build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@twostoryrobot/storybook-addon-docgen",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twostoryrobot/storybook-addon-docgen",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Generates documentation using react-docgen",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
semaphore wasn't running the `npm run build` task. Need to republish